### PR TITLE
Add additional clarity to company laptop rules

### DIFF
--- a/security/devices.md
+++ b/security/devices.md
@@ -52,9 +52,9 @@ Additional guidelines apply to company laptops; you should:
 
 1. Have full hard drive encryption enabled (for macOS, [use FileVault](https://support.apple.com/en-us/HT204837))
 1. Never connect anything to your company computer that was not purchased and approved by Parallel.
+  * This rule includes anything that you physically plug into your computer - including external hubs, lights, keyboards, mice, headphones, etc.  It also includes all thumbdrives / jump drives, external hard drives, keyboards, monitors, USB devices, etc.  If you plug it in, it must have been provided by Parallel or received prior approval.
   * This includes connecting via wires (USB, Thunderbolt, etc) as well as via Bluetooth.
-  * This prohibition includes all thumbdrives / jump drives, external hard drives, keyboards, monitors, USB devices, etc. not provided by Parallel.
-  * If you have a personal device you'd like to plug in (for instance, a personal monitor), you may email [security@parallelmarkets.com](mailto:security@parallelmarkets.com) to request a specific exception to this rule.
+  * If you have a personal device you'd like to plug in (for instance, a personal monitor or USB hub), you may email [security@parallelmarkets.com](mailto:security@parallelmarkets.com) to request approval.  Make sure to include a link to the product (or the make, model, and description).
 
 ## Network :satellite:
 In general, we operate with a stance of [Zero Trust](https://www.cloudflare.com/learning/security/glossary/what-is-zero-trust/).  We assume that our internal networks could be compromised and seek to secure resources rather than networks.  Given the nature of our [remote workforce]({{ site.baseurl }}{% link work/index.md %}) and our utilization of cloud services, we cannot assume that resources are located within an enterprise-owned network boundary.

--- a/security/devices.md
+++ b/security/devices.md
@@ -54,6 +54,7 @@ Additional guidelines apply to company laptops; you should:
 1. Never connect anything to your company computer that was not purchased and approved by Parallel.
   * This rule includes anything that you physically plug into your computer - including external hubs, lights, keyboards, mice, headphones, etc.  It also includes all thumbdrives / jump drives, external hard drives, keyboards, monitors, USB devices, etc.  If you plug it in, it must have been provided by Parallel or received prior approval.
   * This includes connecting via wires (USB, Thunderbolt, etc) as well as via Bluetooth.
+  * Even the most seemingly innocuous peripheral could potentially pose risk to the company. It is critically important that you seek approval before connecting *any* external device (via wires or Bluetooth). The dangers are [well documented](https://www.sciencedaily.com/releases/2019/02/190225192119.htm) by both [consumer press](https://www.cnet.com/tech/services-and-software/usb-devices-spreading-viruses/) and the [US Government](https://www.cisa.gov/uscert/sites/default/files/publications/RisksOfPortableDevices.pdf).
   * If you have a personal device you'd like to plug in (for instance, a personal monitor or USB hub), you may email [security@parallelmarkets.com](mailto:security@parallelmarkets.com) to request approval.  Make sure to include a link to the product (or the make, model, and description).
 
 ## Network :satellite:


### PR DESCRIPTION
Add additional examples of things with wires - i.e., things that require prior approval for usage with a company laptop.