### PR TITLE
Update LastPass and CloudFlare WARP references

### DIFF
--- a/security/devices.md
+++ b/security/devices.md
@@ -60,4 +60,4 @@ Additional guidelines apply to company laptops; you should:
 ## Network :satellite:
 In general, we operate with a stance of [Zero Trust](https://www.cloudflare.com/learning/security/glossary/what-is-zero-trust/).  We assume that our internal networks could be compromised and seek to secure resources rather than networks.  Given the nature of our [remote workforce]({{ site.baseurl }}{% link work/index.md %}) and our utilization of cloud services, we cannot assume that resources are located within an enterprise-owned network boundary.
 
-To help reduce networking risks, we utilize [Cloudflare for Teams](https://www.cloudflare.com/teams/).  Everyone should install and utilize the Warp client (instructions can be found [here](https://docs.google.com/document/d/1gd_BvZug6p0SD9j77njP3fSa33nyM3cNOMAbqJ5C7fA/edit)).
+To help reduce networking risks, we utilize [Cloudflare for Teams](https://www.cloudflare.com/teams/).  Everyone should install and utilize the Warp client (downloads can be found [here](https://developers.cloudflare.com/warp-client/get-started/)).

--- a/security/devices.md
+++ b/security/devices.md
@@ -60,4 +60,4 @@ Additional guidelines apply to company laptops; you should:
 ## Network :satellite:
 In general, we operate with a stance of [Zero Trust](https://www.cloudflare.com/learning/security/glossary/what-is-zero-trust/).  We assume that our internal networks could be compromised and seek to secure resources rather than networks.  Given the nature of our [remote workforce]({{ site.baseurl }}{% link work/index.md %}) and our utilization of cloud services, we cannot assume that resources are located within an enterprise-owned network boundary.
 
-To help reduce networking risks, we utilize [Cloudflare for Teams](https://www.cloudflare.com/teams/).  Everyone should install and utilize the Warp client (downloads can be found [here](https://developers.cloudflare.com/warp-client/get-started/)).
+To help reduce networking risks, we utilize [Cloudflare for Teams](https://www.cloudflare.com/teams/).  Everyone should install and utilize the Warp client via the Self Service app.

--- a/security/processes.md
+++ b/security/processes.md
@@ -23,7 +23,7 @@ Do not sign up for a new service on behalf of Parallel without first receiving p
 This includes signing into web pages and web apps using your @parallelmarkets.com Google sign-in.
 
 ### Passwords
-Use a password manager!  A password manager let you memorize one strong password, and then it generates and manages strong, unique passwords for every site for which you have a login.  Employees can install [LastPass](https://www.lastpass.com/), which should be preloaded on company Chromebooks. 
+Use a password manager!  A password manager let you memorize one strong password, and then it generates and manages strong, unique passwords for every site for which you have a login.  Employees can install [LastPass](https://www.lastpass.com/), which should be preloaded on company devices. 
 
 1. Make sure you use a separate password for every service (for instance, your Gmail password should be different than your Slack password).
 1. You should use the password autogeneration capabilities of your password manager to generate secure passwords.  Passwords should:

--- a/security/processes.md
+++ b/security/processes.md
@@ -23,7 +23,7 @@ Do not sign up for a new service on behalf of Parallel without first receiving p
 This includes signing into web pages and web apps using your @parallelmarkets.com Google sign-in.
 
 ### Passwords
-Use a password manager!  A password manager let you memorize one strong password, and then it generates and manages strong, unique passwords for every site for which you have a login.  Employees can install [LastPass](https://www.lastpass.com/) via the Self Service App that is installed on your company device.
+Use a password manager!  A password manager let you memorize one strong password, and then it generates and manages strong, unique passwords for every site for which you have a login.  Employees can install [LastPass](https://www.lastpass.com/), which should be preloaded on company Chromebooks. 
 
 1. Make sure you use a separate password for every service (for instance, your Gmail password should be different than your Slack password).
 1. You should use the password autogeneration capabilities of your password manager to generate secure passwords.  Passwords should:


### PR DESCRIPTION
* Replace link to deleted CloudFlare WARP Google Doc with getting started web page
* Remove outdated reference to LastPass availability via Self Service App