### PR TITLE
Remove Google Tag Manager in favor of Parallel Analytics

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GEM
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
-    ethon (0.15.0)
+    ethon (0.16.0)
       ffi (>= 1.15.0)
     eventmachine (1.2.7)
     execjs (2.8.1)
@@ -270,7 +270,7 @@ GEM
     unf_ext (0.0.8.2)
     unicode-display_width (1.8.0)
     webrick (1.7.0)
-    zeitwerk (2.6.1)
+    zeitwerk (2.6.6)
 
 PLATFORMS
   ruby

--- a/_config.yml
+++ b/_config.yml
@@ -22,8 +22,6 @@ search_enabled: true
 aux_links:
   "Parallel Home": "https://about.parallelmarkets.com"
 
-gtm_id: GTM-NLM5KSZ
-
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list
 # to override the default setting.

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,18 +7,16 @@
 
   <title>{{ page.title }} - {{ site.title }}</title>
   <link rel="stylesheet" href="{{ "/assets/css/just-the-docs-default.css" | absolute_url }}">
-
-  {% if site.gtm_id != nil %}  
-  <!-- Google Tag Manager -->
   <script>
-    (function(w,d,s,l,i){
-      w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','{{ site.gtm_id }}');
+  if (window.location.host === 'about.parallelmarkets.com') {
+    window._pmAnalyticsConfig = {
+      segment_key: 'FsZOMatHS0d0uzap67Vjcic5sR0GAr1j',
+      auto_track_pageview: true,
+      code_name: 'Parallel Handbook Site',
+      code_version: 'production'
+    };
+  }
   </script>
-  <!-- End Google Tag Manager -->
-  {% endif %}
-
   {% if site.search_enabled != nil %}
     <script type="text/javascript" src="{{ "/assets/js/vendor/lunr.min.js" | absolute_url }}"></script>
   {% endif %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -17,6 +17,7 @@
     };
   }
   </script>
+  <script async src="https://web.pm-metrics.com/prod/parallel-analytics.js"></script>
   {% if site.search_enabled != nil %}
     <script type="text/javascript" src="{{ "/assets/js/vendor/lunr.min.js" | absolute_url }}"></script>
   {% endif %}


### PR DESCRIPTION
Remove old usage of Google Tag Manager with our own analytics library.