### PR TITLE
Add note about device safety and non-US holidays

### DIFF
--- a/benefits/general-benefits.md
+++ b/benefits/general-benefits.md
@@ -53,4 +53,4 @@ We designate ten holidays each calendar year for employees in the United States.
 * Christmas Day
 * New Year's Eve
 
-[1]: https://secure.justworks.com/benefits/company_benefits_overviews/9f88a900-9a1f-4c16-ace0-39ff2c10d913/show
+For employees outside of the United States, please confer with your manager to determine which holidays will be applicable to your employment.

--- a/security/devices.md
+++ b/security/devices.md
@@ -51,6 +51,7 @@ This software should not be disabled or uninstalled.
 Additional guidelines apply to company laptops; you should:
 
 1. Have full hard drive encryption enabled (for macOS, [use FileVault](https://support.apple.com/en-us/HT204837))
+1. Always make sure to completely power off your computer (choose the full "shut down" option, don’t just close the lid or "hibernate") whenever the device is not by your side or in your home. This includes any time the device may be at heightened risk of theft (when left in a hotel room, going through airport security, in a car, etc.).
 1. Never connect anything to your company computer that was not purchased and approved by Parallel.
   * This rule includes anything that you physically plug into your computer - including external hubs, lights, keyboards, mice, headphones, etc.  It also includes all thumbdrives / jump drives, external hard drives, keyboards, monitors, USB devices, etc.  If you plug it in, it must have been provided by Parallel or received prior approval.
   * This includes connecting via wires (USB, Thunderbolt, etc) as well as via Bluetooth.


### PR DESCRIPTION
We should add additional times/cases where company devices should be entirely powered off and a note about non-US employees and holidays.